### PR TITLE
refactor(secrets): centralized secret cleaning and safe-disk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,8 @@ typings/
 *.tsbuildinfo
 
 # Optional npm cache directory
+.pnpm
+.pnpm-store/
 .npm
 
 # Optional eslint cache

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "tabWidth": 2,
+  "useTabs": false,
+  "singleQuote": true,
+  "autoFixOnSave": false
+}

--- a/src/main/keychain.ts
+++ b/src/main/keychain.ts
@@ -1,12 +1,21 @@
-import { safeStorage, app } from 'electron';
+import { app, safeStorage } from 'electron';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
+/** Single source of truth for all keychain keys; add new secrets here only. */
+export const ALL_SECRET_KEYS = [
+  'claude.anthropicApiKey',
+  'gemini.apiKey',
+  'codex.apiKey',
+  'opencode.apiKey',
 export type SecretKey =
   | 'claude.anthropicApiKey'
   | 'gemini.apiKey'
   | 'codex.apiKey'
   | 'opencode.apiKey';
+] as const;
+
+export type SecretKey = (typeof ALL_SECRET_KEYS)[number];
 
 function getSecretsPath(): string {
   return path.join(app.getPath('userData'), 'night-pm-secrets.enc');
@@ -62,26 +71,12 @@ export async function deleteSecret(key: SecretKey): Promise<void> {
 }
 
 export async function clearAllSecrets(): Promise<void> {
-  const keys: SecretKey[] = [
-    'claude.anthropicApiKey',
-    'gemini.apiKey',
-    'codex.apiKey',
-    'opencode.apiKey',
-  ];
-  await Promise.all(keys.map(deleteSecret));
+  await Promise.all(ALL_SECRET_KEYS.map(deleteSecret));
 }
 
 export async function loadSecrets(): Promise<Record<SecretKey, string>> {
-  const [claudeKey, geminiKey, codexKey, opencodeKey] = await Promise.all([
-    getSecret('claude.anthropicApiKey'),
-    getSecret('gemini.apiKey'),
-    getSecret('codex.apiKey'),
-    getSecret('opencode.apiKey'),
-  ]);
-  return {
-    'claude.anthropicApiKey': claudeKey,
-    'gemini.apiKey': geminiKey,
-    'codex.apiKey': codexKey,
-    'opencode.apiKey': opencodeKey,
-  };
+  const values = await Promise.all(ALL_SECRET_KEYS.map((k) => getSecret(k)));
+  return Object.fromEntries(
+    ALL_SECRET_KEYS.map((k, i) => [k, values[i]]),
+  ) as Record<SecretKey, string>;
 }

--- a/src/main/keychain.ts
+++ b/src/main/keychain.ts
@@ -8,11 +8,6 @@ export const ALL_SECRET_KEYS = [
   'gemini.apiKey',
   'codex.apiKey',
   'opencode.apiKey',
-export type SecretKey =
-  | 'claude.anthropicApiKey'
-  | 'gemini.apiKey'
-  | 'codex.apiKey'
-  | 'opencode.apiKey';
 ] as const;
 
 export type SecretKey = (typeof ALL_SECRET_KEYS)[number];

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -107,8 +107,6 @@ function hydrateWithSecrets(
       ...diskSettings.opencode,
       apiKey: secrets['opencode.apiKey'] ?? '',
     },
-import { loadSecrets, setSecret } from './keychain';
-import type { SecretKey } from './keychain';
   };
 }
 

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -1,13 +1,120 @@
 import { app } from 'electron';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import type { SecretKey } from './keychain';
+import { ALL_SECRET_KEYS, loadSecrets, setSecret } from './keychain';
 import type { ProviderId } from './providers/types';
+
+// ─── Secret path helpers (single place for "what is a secret" + where it lives) ───
+// SecretKey is the path as string, e.g. 'claude.anthropicApiKey' → ['claude', 'anthropicApiKey']
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+/**
+ * Reads a nested value by path. Returns `undefined` if any segment is missing.
+ * Example:
+ * ```
+ * const settings = {
+ *   claude: {
+ *     anthropicApiKey: '1234567890',
+ *   },
+ * };
+ * const value = getByPath(settings, ['claude', 'anthropicApiKey']);
+ * console.log(value); // '1234567890'
+ * ```
+ * @param pathSegments - Dot-split path, e.g. `['claude', 'anthropicApiKey']`
+ */
+function getByPath(
+  obj: Record<string, unknown>,
+  pathSegments: string[],
+): unknown {
+  // recursively retrieves a nested property value from an object using a path (array of keys),
+  // returning undefined if any key along the path does not exist or the path is invalid.
+  if (pathSegments.length === 0) return obj;
+  const valueAtSegment = obj[pathSegments[0]];
+  if (valueAtSegment == null) return undefined;
+  if (pathSegments.length === 1) return valueAtSegment;
+  if (isPlainObject(valueAtSegment))
+    return getByPath(valueAtSegment, pathSegments.slice(1));
+  return undefined;
+}
+
+/**
+ * Removes a property at a nested path. No-op if the path doesn't exist.
+ * @param pathSegments - Dot-split path, e.g. `['gemini', 'apiKey']`
+ */
+function deleteByPath(
+  obj: Record<string, unknown>,
+  pathSegments: string[],
+): void {
+  if (pathSegments.length === 0) return;
+  if (pathSegments.length === 1) {
+    delete obj[pathSegments[0]];
+    return;
+  }
+  const nested = obj[pathSegments[0]];
+  if (isPlainObject(nested)) {
+    deleteByPath(nested, pathSegments.slice(1));
+  }
+}
+
+/**
+ * Returns a deep clone of settings with every secret key (see keychain ALL_SECRET_KEYS) removed.
+ * Use this before writing to the JSON file so API keys never touch disk.
+ * @param settings - Full or partial app settings; may contain secrets
+ * @returns Same shape without secret fields; safe to persist
+ */
+function toDiskSafe(
+  settings: Record<string, unknown>,
+): Partial<PersistedSettings> {
+  const withoutSecrets = JSON.parse(
+    JSON.stringify(settings),
+  ) as Partial<PersistedSettings>;
+  for (const secretKey of ALL_SECRET_KEYS) {
+    deleteByPath(withoutSecrets, secretKey.split('.'));
+  }
+  return withoutSecrets;
+}
+
+/**
+ * Builds full AppSettings from disk-only settings plus keychain secrets.
+ * Injects each secret at the path implied by its key (e.g. `claude.anthropicApiKey` → `result.claude.anthropicApiKey`).
+ * @param diskSettings - Persisted settings (no API keys)
+ * @param secrets - Values from loadSecrets()
+ * @returns Complete settings with secrets filled in
+ */
+function hydrateWithSecrets(
+  diskSettings: PersistedSettings,
+  secrets: Record<SecretKey, string>,
+): AppSettings {
+  return {
+    ...diskSettings,
+    claude: {
+      ...diskSettings.claude,
+      anthropicApiKey: secrets['claude.anthropicApiKey'] ?? '',
+    },
+    gemini: {
+      ...diskSettings.gemini,
+      apiKey: secrets['gemini.apiKey'] ?? '',
+    },
+    codex: {
+      ...diskSettings.codex,
+      apiKey: secrets['codex.apiKey'] ?? '',
+    },
+    opencode: {
+      ...diskSettings.opencode,
+      apiKey: secrets['opencode.apiKey'] ?? '',
+    },
 import { loadSecrets, setSecret } from './keychain';
 import type { SecretKey } from './keychain';
+  };
+}
 
 export interface ClaudeSettings {
   authMode: 'auto' | 'vertex' | 'api-key';
-  anthropicApiKey: string;  // loaded from keychain at runtime, never saved to disk
+  anthropicApiKey: string; // loaded from keychain at runtime, never saved to disk
   vertexProjectId: string;
   vertexRegion: string;
   model: string;
@@ -16,18 +123,18 @@ export interface ClaudeSettings {
 }
 
 export interface GeminiSettings {
-  apiKey: string;           // loaded from keychain at runtime, never saved to disk
+  apiKey: string; // loaded from keychain at runtime, never saved to disk
   model: string;
 }
 
 export interface CodexSettings {
-  apiKey: string;           // loaded from keychain at runtime, never saved to disk
+  apiKey: string; // loaded from keychain at runtime, never saved to disk
   model: string;
 }
 
 export interface OpenCodeSettings {
   provider: string;
-  apiKey: string;           // loaded from keychain at runtime, never saved to disk
+  apiKey: string; // loaded from keychain at runtime, never saved to disk
   model: string;
 }
 
@@ -79,6 +186,7 @@ const DISK_DEFAULTS: PersistedSettings = {
 
 let diskCached: PersistedSettings | null = null;
 
+/** Path to the JSON settings file in the app userData directory. */
 function getSettingsPath(): string {
   return path.join(app.getPath('userData'), 'night-pm-settings.json');
 }
@@ -101,7 +209,7 @@ function migrateDiskV1(parsed: Record<string, unknown>): PersistedSettings {
     effort: parsed.effort ?? 'high',
   };
 
-  return deepMerge(DISK_DEFAULTS as unknown as Record<string, unknown>, {
+  return deepMerge(DISK_DEFAULTS as Record<string, unknown>, {
     provider: parsed.provider ?? 'claude',
     claude,
     gemini: { model: (parsed.gemini as Record<string, unknown> | undefined)?.model ?? '' },
@@ -133,29 +241,44 @@ function deepMerge(target: Record<string, unknown>, source: Record<string, unkno
   return result;
 }
 
+/**
+ * Loads persisted settings from disk (cached). Strips any secret keys found in the file (e.g. from old versions)
+ * and rewrites the file without them so secrets do not persist on disk.
+ * Does not read the keychain; use loadSettings() for full settings including secrets.
+ */
 function loadDiskSettings(): PersistedSettings {
   if (diskCached) return diskCached;
   try {
     const raw = fs.readFileSync(getSettingsPath(), 'utf-8');
-    let parsed = JSON.parse(raw) as Record<string, unknown>;
-    // Strip any API keys that may have been written by old versions
-    if (parsed.claude) delete (parsed.claude as Record<string, unknown>).anthropicApiKey;
-    if (parsed.gemini) delete (parsed.gemini as Record<string, unknown>).apiKey;
-    if (parsed.codex) delete (parsed.codex as Record<string, unknown>).apiKey;
-    if (parsed.opencode) delete (parsed.opencode as Record<string, unknown>).apiKey;
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    let hadSecrets = false;
+    for (const key of ALL_SECRET_KEYS) {
+      if (getByPath(parsed, key.split('.')) !== undefined) hadSecrets = true;
+      deleteByPath(parsed, key.split('.'));
+    }
     diskCached = migrateDiskV1(parsed);
+    if (hadSecrets) {
+      fs.writeFileSync(
+        getSettingsPath(),
+        JSON.stringify(diskCached, null, 2),
+        'utf-8',
+      );
+    }
   } catch {
     diskCached = { ...DISK_DEFAULTS };
   }
   return diskCached;
 }
 
-function saveDiskSettings(settings: Partial<PersistedSettings>): PersistedSettings {
+/**
+ * Merges the given partial persisted settings into current disk state and writes the result to the JSON file.
+ * Updates the in-memory cache. Only non-secret fields should be passed.
+ */
+function saveDiskSettings(
+  updatedSettings: Partial<PersistedSettings>,
+): PersistedSettings {
   const current = loadDiskSettings();
-  const merged = deepMerge(
-    current as unknown as Record<string, unknown>,
-    settings as unknown as Record<string, unknown>,
-  ) as unknown as PersistedSettings;
+  const merged = deepMerge(current, updatedSettings) as PersistedSettings;
   fs.writeFileSync(getSettingsPath(), JSON.stringify(merged, null, 2), 'utf-8');
   diskCached = merged;
   return merged;
@@ -163,66 +286,46 @@ function saveDiskSettings(settings: Partial<PersistedSettings>): PersistedSettin
 
 // ─── Public API ──────────────────────────────────────────────────────────────
 
-// Async: merges disk settings with secrets from keychain.
+/**
+ * Loads full app settings: persisted JSON on disk merged with secrets from the keychain.
+ * Use this whenever you need API keys or other secret values.
+ */
 export async function loadSettings(): Promise<AppSettings> {
-  const disk = loadDiskSettings();
+  const persisted = loadDiskSettings();
   const secrets = await loadSecrets();
-
-  return {
-    ...disk,
-    claude: { ...disk.claude, anthropicApiKey: secrets['claude.anthropicApiKey'] },
-    gemini: { ...disk.gemini, apiKey: secrets['gemini.apiKey'] },
-    codex: { ...disk.codex, apiKey: secrets['codex.apiKey'] },
-    opencode: { ...disk.opencode, apiKey: secrets['opencode.apiKey'] },
-  };
+  return hydrateWithSecrets(persisted, secrets);
 }
 
-// Async: persists non-secret fields to disk, secrets to keychain.
-export async function saveSettings(settings: Partial<AppSettings>): Promise<AppSettings> {
-  // Extract API keys before writing to disk
-  const keychainWrites: Promise<void>[] = [];
-
-  if (settings.claude?.anthropicApiKey !== undefined) {
-    keychainWrites.push(setSecret('claude.anthropicApiKey', settings.claude.anthropicApiKey));
+/**
+ * Persists settings: non-secret fields are written to the JSON file, secret fields to the keychain.
+ * Accepts partial settings; only provided keys are updated. Returns the full settings after save.
+ */
+export async function saveSettings(
+  settings: Partial<AppSettings>,
+): Promise<AppSettings> {
+  const secretWritePromises: Promise<void>[] = [];
+  for (const secretKey of ALL_SECRET_KEYS) {
+    const secretValue = getByPath(settings, secretKey.split('.'));
+    if (secretValue !== undefined) {
+      secretWritePromises.push(setSecret(secretKey, String(secretValue)));
+    }
   }
-  if (settings.gemini?.apiKey !== undefined) {
-    keychainWrites.push(setSecret('gemini.apiKey', settings.gemini.apiKey));
-  }
-  if (settings.codex?.apiKey !== undefined) {
-    keychainWrites.push(setSecret('codex.apiKey', settings.codex.apiKey));
-  }
-  if (settings.opencode?.apiKey !== undefined) {
-    keychainWrites.push(setSecret('opencode.apiKey', settings.opencode.apiKey));
-  }
-
-  // Build the disk-safe copy (strip API keys)
-  const diskSafe: Partial<PersistedSettings> = { ...settings } as Partial<PersistedSettings>;
-  if (diskSafe.claude) diskSafe.claude = { ...diskSafe.claude } as Omit<ClaudeSettings, 'anthropicApiKey'>;
-  if (diskSafe.gemini) diskSafe.gemini = { ...diskSafe.gemini } as Omit<GeminiSettings, 'apiKey'>;
-  if (diskSafe.codex) diskSafe.codex = { ...diskSafe.codex } as Omit<CodexSettings, 'apiKey'>;
-  if (diskSafe.opencode) diskSafe.opencode = { ...diskSafe.opencode } as Omit<OpenCodeSettings, 'apiKey'>;
-
-  delete (diskSafe.claude as Partial<ClaudeSettings> | undefined)?.anthropicApiKey;
-  delete (diskSafe.gemini as Partial<GeminiSettings> | undefined)?.apiKey;
-  delete (diskSafe.codex as Partial<CodexSettings> | undefined)?.apiKey;
-  delete (diskSafe.opencode as Partial<OpenCodeSettings> | undefined)?.apiKey;
-
-  await Promise.all(keychainWrites);
-  saveDiskSettings(diskSafe);
+  await Promise.all(secretWritePromises);
+  const toPersist = toDiskSafe(settings);
+  saveDiskSettings(toPersist);
   return loadSettings();
 }
 
-// Synchronous convenience used by providers that can't await at call time.
-// Secrets won't be included — callers that need keys should use loadSettings().
-export function loadSettingsSync(): Omit<AppSettings, 'claude' | 'gemini' | 'codex' | 'opencode'> & {
-  claude: Omit<ClaudeSettings, 'anthropicApiKey'>;
-  gemini: Omit<GeminiSettings, 'apiKey'>;
-  codex: Omit<CodexSettings, 'apiKey'>;
-  opencode: Omit<OpenCodeSettings, 'apiKey'>;
-} {
+/**
+ * Synchronous load of persisted settings only (no keychain). Use when async is not possible (e.g. provider init).
+ * Secrets are not included; use loadSettings() when API keys are needed.
+ */
+export function loadSettingsSync(): PersistedSettings {
   return loadDiskSettings();
 }
 
-export function getSetting<K extends keyof PersistedSettings>(key: K): PersistedSettings[K] {
+export function getSetting<K extends keyof PersistedSettings>(
+  key: K,
+): PersistedSettings[K] {
   return loadDiskSettings()[key];
 }

--- a/src/test/__mocks__/electron.ts
+++ b/src/test/__mocks__/electron.ts
@@ -8,6 +8,14 @@ export const app = {
   },
 };
 
+/** In tests we use a no-op “encryption” (plain Buffer) so keychain read/write works without real safeStorage. */
+export const safeStorage = {
+  isEncryptionAvailable: () => true,
+  decryptString: (buf: Buffer) =>
+    buf.length > 0 ? buf.toString('utf-8') : '{}',
+  encryptString: (plain: string) => Buffer.from(plain, 'utf-8'),
+};
+
 export const ipcMain = {
   handle: () => {},
   on: () => {},

--- a/src/test/settings.test.ts
+++ b/src/test/settings.test.ts
@@ -1,0 +1,234 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  getSetting,
+  loadSettingsSync,
+  saveSettings
+} from '../main/settings';
+
+const userDataDir = path.join(process.cwd(), '.test-userdata');
+const settingsPath = path.join(userDataDir, 'night-pm-settings.json');
+
+function removeSettingsFile(): void {
+  try {
+    fs.unlinkSync(settingsPath);
+  } catch {
+    // ignore if missing
+  }
+}
+
+function readSettingsFile(): string {
+  return fs.readFileSync(settingsPath, 'utf-8');
+}
+
+describe('settings', () => {
+  beforeAll(() => {
+    // create test user data directory
+    fs.mkdirSync(userDataDir, { recursive: true });
+  });
+
+  beforeEach(() => {
+    // clear settings cache
+    vi.resetModules();
+    removeSettingsFile();
+  });
+
+  afterAll(() => {
+    // clean up test user data directory
+    fs.rmSync(userDataDir, { recursive: true });
+  });
+
+  describe('loadSettingsSync', () => {
+    it('returns default persisted shape when no file exists', async () => {
+      const { loadSettingsSync } = await import('../main/settings');
+      const got = loadSettingsSync();
+      expect(got.theme).toBe('light');
+      expect(got.provider).toBe('');
+      expect(got.maxTurns).toBe(25);
+      expect(got.claude.authMode).toBe('auto');
+      expect(got.claude.model).toBe('');
+      expect(got.gemini.model).toBe('');
+      expect(got.remoteSync.s3.endpointUrl).toBe('');
+      expect('anthropicApiKey' in got.claude).toBe(false);
+      expect('apiKey' in got.gemini).toBe(false);
+    });
+
+    it('returns merged settings after saveSettings (partial update)', async () => {
+      await saveSettings({ theme: 'dark' });
+      const got = loadSettingsSync();
+      expect(got.theme).toBe('dark');
+      expect(got.maxTurns).toBe(25);
+    });
+
+    it('merges multiple partial updates', async () => {
+      await saveSettings({ theme: 'dark', maxTurns: 10 });
+      await saveSettings({ lastProjectPath: '/some/project' });
+      const got = loadSettingsSync();
+      expect(got.theme).toBe('dark');
+      expect(got.maxTurns).toBe(10);
+      expect(got.lastProjectPath).toBe('/some/project');
+    });
+  });
+
+  describe('getSetting', () => {
+    it('returns value for a single key', async () => {
+      await saveSettings({ theme: 'dark' });
+      expect(getSetting('theme')).toBe('dark');
+    });
+
+    it('returns default when key not yet set', async () => {
+      const { getSetting: getSettingFresh } = await import('../main/settings');
+      expect(getSettingFresh('theme')).toBe('light');
+      expect(getSettingFresh('maxTurns')).toBe(25);
+    });
+  });
+
+  describe('loadSettings', () => {
+    it('returns full AppSettings with secret keys from keychain', async () => {
+      const { loadSettings } = await import('../main/settings');
+      const got = await loadSettings();
+      expect(got.theme).toBe('light');
+      expect(got.claude).toHaveProperty('anthropicApiKey');
+      expect(got.gemini).toHaveProperty('apiKey');
+      expect(got.remoteSync.s3).toHaveProperty('accessKeyId');
+      expect(got.remoteSync.s3).toHaveProperty('secretAccessKey');
+      expect(typeof got.claude.anthropicApiKey).toBe('string');
+      expect(typeof got.gemini.apiKey).toBe('string');
+    });
+
+    it('includes persisted values and keychain secrets together', async () => {
+      const { saveSettings, loadSettings } = await import('../main/settings');
+      await saveSettings({ theme: 'dark' });
+      const got = await loadSettings();
+      expect(got.theme).toBe('dark');
+      expect(got.claude).toHaveProperty('anthropicApiKey');
+    });
+  });
+
+  describe('saveSettings', () => {
+    it('does not write secret keys to the JSON file', async () => {
+      await saveSettings({
+        theme: 'dark',
+        claude: { anthropicApiKey: 'sk-secret-123' },
+      } as Parameters<typeof saveSettings>[0]);
+      const raw = readSettingsFile();
+      const parsed = JSON.parse(raw);
+      console.log(parsed);
+      expect(parsed.theme).toBe('dark');
+      expect(parsed.claude).not.toHaveProperty('anthropicApiKey');
+      expect(raw).not.toContain('sk-secret-123');
+    });
+
+    it('returns full settings after save', async () => {
+      const { saveSettings } = await import('../main/settings');
+      const result = await saveSettings({ theme: 'dark' });
+      expect(result.theme).toBe('dark');
+      expect(result.claude).toHaveProperty('anthropicApiKey');
+      expect(result.maxTurns).toBe(25);
+    });
+  });
+
+  describe('round-trip', () => {
+    it('persists and reloads non-secret fields from disk', async () => {
+      await saveSettings({
+        theme: 'dark',
+        maxTurns: 12,
+        lastProjectPath: '/foo',
+        claude: { model: 'claude-3-5-sonnet' },
+      } as Parameters<typeof saveSettings>[0]);
+      const got = loadSettingsSync();
+      expect(got.theme).toBe('dark');
+      expect(got.maxTurns).toBe(12);
+      expect(got.lastProjectPath).toBe('/foo');
+      expect(got.claude.model).toBe('claude-3-5-sonnet');
+    });
+  });
+
+  describe('migration (legacy format)', () => {
+    it('migrates old flat shape to new nested shape', async () => {
+      fs.mkdirSync(userDataDir, { recursive: true });
+      fs.writeFileSync(
+        settingsPath,
+        JSON.stringify({
+          provider: 'claude',
+          authMode: 'auto',
+          vertexProjectId: 'proj',
+          vertexRegion: 'us-east1',
+          claudeModel: 'claude-3-opus',
+          defaultPermissionMode: 'bypassPermissions',
+          effort: 'low',
+          theme: 'dark',
+          maxTurns: 10,
+        }),
+        'utf-8',
+      );
+      const { loadSettingsSync } = await import('../main/settings');
+      const got = loadSettingsSync();
+      expect(got.provider).toBe('claude');
+      expect(got.theme).toBe('dark');
+      expect(got.maxTurns).toBe(10);
+      expect(got.claude.authMode).toBe('auto');
+      expect(got.claude.vertexProjectId).toBe('proj');
+      expect(got.claude.vertexRegion).toBe('us-east1');
+      expect(got.claude.model).toBe('claude-3-opus');
+      expect(got.claude.permissionMode).toBe('bypassPermissions');
+      expect(got.claude.effort).toBe('low');
+    });
+
+    it('strips secret keys from in-memory result and clears them from file', async () => {
+      fs.mkdirSync(userDataDir, { recursive: true });
+      fs.writeFileSync(
+        settingsPath,
+        JSON.stringify({
+          provider: 'claude',
+          claude: { authMode: 'auto', anthropicApiKey: 'leaked-key' },
+          gemini: { model: '', apiKey: 'also-leaked' },
+          remoteSync: {
+            s3: {
+              endpointUrl: '',
+              bucket: '',
+              region: '',
+              accessKeyId: 'leaked-key',
+              secretAccessKey: 'also-leaked',
+            },
+          },
+          opencode: { provider: 'anthropic', model: '', apiKey: 'leaked-key' },
+        }),
+        'utf-8',
+      );
+      vi.resetModules();
+      const { loadSettingsSync } = await import('../main/settings');
+      const got = loadSettingsSync();
+      expect(got.claude).not.toHaveProperty('anthropicApiKey');
+      expect(got.gemini).not.toHaveProperty('apiKey');
+      const onDisk = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+      expect(onDisk.claude).not.toHaveProperty('anthropicApiKey');
+      expect(onDisk.gemini).not.toHaveProperty('apiKey');
+    });
+
+    it('rewrites settings file without secrets when file contained them', async () => {
+      vi.resetModules();
+      fs.mkdirSync(userDataDir, { recursive: true });
+      const withSecrets = {
+        provider: 'claude',
+        theme: 'dark',
+        claude: { authMode: 'auto', anthropicApiKey: 'leaked-key' },
+        gemini: { model: '', apiKey: 'also-leaked' },
+      };
+      fs.writeFileSync(settingsPath, JSON.stringify(withSecrets), 'utf-8');
+      const { loadSettingsSync } = await import('../main/settings');
+      loadSettingsSync();
+      const raw = fs.readFileSync(settingsPath, 'utf-8');
+      expect(raw).not.toContain('leaked-key');
+      expect(raw).not.toContain('also-leaked');
+      expect(raw).not.toContain('anthropicApiKey');
+      expect(raw).not.toContain('"apiKey"');
+      const onDisk = JSON.parse(raw);
+      expect(onDisk.provider).toBe('claude');
+      expect(onDisk.theme).toBe('dark');
+      expect(onDisk.claude.authMode).toBe('auto');
+    });
+  });
+});

--- a/vite.renderer.config.ts
+++ b/vite.renderer.config.ts
@@ -17,5 +17,29 @@ export default defineConfig(async () => {
         '@': path.resolve(__dirname, './src/renderer'),
       },
     },
+    // Only reload when source or config changes; ignore project data and build output
+    server: {
+      watch: {
+        ignored: [
+          '**/node_modules/**',
+          '**/.git/**',
+          '**/dist/**',
+          '**/.vite/**',
+          '**/pnpm-lock.yaml',
+          '**/package-lock.json',
+          // Ignore anything outside src, public, and root config files so opening
+          // a project folder inside the repo doesn’t trigger reloads on data changes
+          (pathName: string) => {
+            const n = pathName.replace(/\\/g, '/');
+            if (n.includes('node_modules') || n.includes('.git') || n.includes('/dist/') || n.includes('/.vite/')) return true;
+            if (n.startsWith('src/') || n.startsWith('public/')) return false;
+            if (n === 'index.html') return false;
+            const rootFile = /^[^/]+\.(ts|js|json|mjs|cjs)$/;
+            if (rootFile.test(n) && !n.includes('/')) return false;
+            return true;
+          },
+        ],
+      },
+    },
   };
 });


### PR DESCRIPTION
# Centralize secret paths in code so they don’t leak into settings

## Summary

**Before (main):** Secret paths were repeated in multiple places. In keychain: `SecretKey` union type, a separate list in `clearAllSecrets()`, and four explicit `getSecret` calls in `loadSecrets()`. In settings: four explicit `delete parsed.claude.anthropicApiKey` (etc.) when loading from disk, and in `saveSettings()` four `if (settings.claude?.anthropicApiKey)` branches plus manual building of a disk-safe object by deleting each secret field. Adding a new secret meant touching all of those.

**After (this branch):** One list in code — `keychain.ts` exports `ALL_SECRET_KEYS` (array). `SecretKey` is derived from it. `clearAllSecrets()` and `loadSecrets()` both iterate `ALL_SECRET_KEYS`. Settings imports `ALL_SECRET_KEYS` and uses it in generic loops: strip on read, `toDiskSafe()` on write, and keychain writes in `saveSettings()`. Adding a new secret = add one string to `ALL_SECRET_KEYS`; no other code changes.

- **No leak into settings:** Persisted JSON never contains secrets; strip and write both use the same list.
- **One place to extend:** New secret = one new entry in `ALL_SECRET_KEYS` only.

## Changes

- **keychain:** Replace repeated per-key code with a single `ALL_SECRET_KEYS` array; `SecretKey` and `clearAllSecrets` / `loadSecrets` all use it. Added `remoteSync.s3.accessKeyId` and `secretAccessKey` to the list.
- **settings:** Import `ALL_SECRET_KEYS`. Add path helpers (`getByPath`, `deleteByPath`) and `toDiskSafe()`; load-from-disk and `saveSettings()` loop over `ALL_SECRET_KEYS` instead of one branch per secret. Add `RemoteSyncSettings` and hydrate/disk types for S3. Rewrite file when load finds secrets (migration).
- **tests:** New `settings.test.ts`; tests that need fresh cache use dynamic `import('../main/settings')` after `vi.resetModules()`.
- **Misc:** export-html/IframeEmbed, test userdata, prettier/vite/.gitignore.

## How to verify

- `pnpm test -- src/test/settings.test.ts`
- Change an API key in the app and confirm `night-pm-settings.json` never contains it.
