### PR TITLE
Refresh sidebar when active project changes (MCP)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import { app, BrowserWindow, ipcMain, Menu } from 'electron';
 import started from 'electron-squirrel-startup';
 import { registerIpcHandlers } from './main/ipc-handlers';
-import { createMainWindow, getThoughtsWindow, registerWindowIpc } from './main/windows';
+import { createMainWindow, getMainWindow, getThoughtsWindow, registerWindowIpc } from './main/windows';
 import { registerShortcuts, unregisterShortcuts } from './main/shortcuts';
 import { startConversation, sendFollowup, stopConversation, listSessions, getActiveProviderId } from './main/engine';
 import { loadSettings, saveSettings } from './main/settings';
@@ -20,9 +20,15 @@ app.setName('Night PM');
 let activeProjectPath: string | null = null;
 let rootDirPath: string | null = null;
 
+/**
+ * Set the active project and save the settings.
+ * Send a message to the main window to notify the renderer that the active project has changed.
+ * @param projectPath
+ */
 function setActiveProject(projectPath: string) {
   activeProjectPath = projectPath;
   void saveSettings({ selectedProjectPath: projectPath });
+  sendToWindow(getMainWindow(), 'app:activeProjectChanged', projectPath);
 }
 
 function sendToWindow(win: BrowserWindow | null, channel: string, ...args: unknown[]) {
@@ -30,6 +36,9 @@ function sendToWindow(win: BrowserWindow | null, channel: string, ...args: unkno
     win.webContents.send(channel, ...args);
   }
 }
+
+// Keep a reference so the menu model isn't GC'd; avoids macOS "representedObject is not a WeakPtrToElectronMenuModelAsNSObject" warning.
+let applicationMenu: Electron.Menu | null = null;
 
 app.on('ready', () => {
   void (async () => {
@@ -40,7 +49,8 @@ app.on('ready', () => {
     { role: 'viewMenu' },
     { role: 'windowMenu' },
   ];
-  Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+  applicationMenu = Menu.buildFromTemplate(template);
+  Menu.setApplicationMenu(applicationMenu);
 
   registerIpcHandlers();
   registerWindowIpc();
@@ -198,5 +208,5 @@ app.on('will-quit', () => {
   unregisterShortcuts();
   stopConversation('thought');
   stopConversation('console');
-  stopMcpHttpServer().catch(() => {});
+  stopMcpHttpServer().catch((e) => console.error('[MCP HTTP] Error stopping:', e));
 });

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -13,6 +13,8 @@ contextBridge.exposeInMainWorld("nightAPI", {
   app: {
     setActiveProject: (p: string) =>
       ipcRenderer.invoke("app:setActiveProject", p),
+    onActiveProjectChanged: (cb: (projectPath: string) => void) =>
+      onIpc("app:activeProjectChanged", cb as (...a: unknown[]) => void),
   },
   window: {
     minimize: () => ipcRenderer.invoke("window:minimize"),

--- a/src/renderer/components/Sidebar/Sidebar.tsx
+++ b/src/renderer/components/Sidebar/Sidebar.tsx
@@ -6,7 +6,6 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { useAppStore } from '../../store';
 import { FileTree } from './FileTree';
 import { useTheme } from '../../hooks/useTheme';
-import { cn } from '@/lib/utils';
 
 interface SidebarProps {
   onOpenSettings: () => void;
@@ -50,6 +49,14 @@ export function Sidebar({ onOpenSettings, onOpenConsole, onOpenAllCalendars, onO
       cleanup();
     };
   }, [rootPath]);
+
+  // Sync store when active project changes from main (e.g. via MCP project_set_active)
+  useEffect(() => {
+    const unsubscribe = window.nightAPI.app.onActiveProjectChanged((projectPath) => {
+      setSelectedProject(projectPath);
+    });
+    return unsubscribe;
+  }, []);
 
   async function handleOpenDirectory() {
     const dirPath = await window.nightAPI.dialog.openDirectory();

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -200,6 +200,7 @@ export interface ProviderAvailability {
 export interface NightAPI {
   app: {
     setActiveProject: (projectPath: string) => Promise<void>;
+    onActiveProjectChanged: (callback: (projectPath: string) => void) => () => void;
   };
   window: {
     minimize: () => Promise<void>;


### PR DESCRIPTION
## Summary
When the active project is changed by **McpServer** or **InAppMcpConsole**, the sidebar now refreshes so the UI stays in sync with the selected project.

## Changes
- **main**: Subscribe to active-project updates and notify the renderer via preload
- **preload**: New IPC handler so the renderer can listen for project changes
- **Sidebar**: Re-subscribe to project data when the active project changes
- **types**: Renderer type for the new IPC channel

## Why
Previously, switching the active project from MCP (e.g. `set_active_project` or the in-app console) did not refresh the sidebar. Users had to manually switch project or reload to see the correct tree.